### PR TITLE
Bootstrap: elect Bridger Farnsworth and Rachel Pickerel as directors

### DIFF
--- a/.github/voters.yml
+++ b/.github/voters.yml
@@ -2,13 +2,11 @@
 # All PRs require majority consent per Section 7.4 of the Bylaws.
 # Majority is calculated automatically as floor(n/2)+1 of effective voters,
 # adjusted for any recusals declared in the PR description.
-#
-# This file reflects the interim period before the full founding board is
-# seated. Update via PR approved by all then-current voters when board
-# composition changes.
 
 voters:
   - ENLinden              # Enik Nadir Linden: Executive Director, Class III
+  - bridgerfarnsworth     # Bridger Ryan Farnsworth: Board Chair, Class II
+  - AuroraEndante         # Rachel B. Pickerel: Class I
 
 allow_self_approve: true
 exclude_author: false

--- a/records/2026-06-23_director_election_consent.md
+++ b/records/2026-06-23_director_election_consent.md
@@ -10,8 +10,6 @@ The undersigned, being the sole initial director of restore280 Institute, a Dela
 
 **Electronic Signature Mechanism.** The undersigned's approval of the pull request introducing this document into the governance repository at `https://github.com/restore280/governance` constitutes a valid electronic signature, with the same legal effect as a handwritten signature. The timestamp and username recorded by GitHub for that approval constitute the date and identity of the signature.
 
-**Note on pending legal name change.** The initial director, Enik Nadir Linden, has a petition for a legal name change pending in Oneida County Supreme Court, New York (case number EFCA2026-001741). As of the effective date of this consent, that petition may or may not have been granted; this director's legal name may at that time still be Enoch Richard Lindeman, or may have become Enik Nadir Linden upon entry of the court's order. This consent is executed under that director's legal name as of the date of execution and remains fully effective and binding regardless of the status of that petition at the time of execution or thereafter.
-
 ---
 
 ## Recitals

--- a/records/2026-06-23_director_election_consent.md
+++ b/records/2026-06-23_director_election_consent.md
@@ -1,0 +1,56 @@
+# WRITTEN CONSENT OF THE INITIAL DIRECTOR OF RESTORE280 INSTITUTE
+
+*Election of Additional Directors — Effective June 23, 2026*
+
+---
+
+## Preamble
+
+The undersigned, being the sole initial director of restore280 Institute, a Delaware nonprofit corporation (the "Corporation"), acting pursuant to Article VII of the Bylaws and Section 141(f) of the Delaware General Corporation Law, hereby consents in writing to the adoption of the following resolutions without a meeting. This consent has the same force and effect as a vote taken at a duly convened meeting of the Board of Directors.
+
+**Electronic Signature Mechanism.** The undersigned's approval of the pull request introducing this document into the governance repository at `https://github.com/restore280/governance` constitutes a valid electronic signature, with the same legal effect as a handwritten signature. The timestamp and username recorded by GitHub for that approval constitute the date and identity of the signature.
+
+**Note on pending legal name change.** The initial director, Enik Nadir Linden, has a petition for a legal name change pending in Oneida County Supreme Court, New York (case number EFCA2026-001741). As of the effective date of this consent, that petition may or may not have been granted; this director's legal name may at that time still be Enoch Richard Lindeman, or may have become Enik Nadir Linden upon entry of the court's order. This consent is executed under that director's legal name as of the date of execution and remains fully effective and binding regardless of the status of that petition at the time of execution or thereafter.
+
+---
+
+## Recitals
+
+WHEREAS, the Certificate of Incorporation of the Corporation became effective June 23, 2026, naming Enik Nadir Linden as the sole initial director;
+
+WHEREAS, Section 3.2 of the Bylaws provides that the Board shall consist of no fewer than three directors, and the initial Board shall consist of three directors;
+
+WHEREAS, Section 3.3 of the Bylaws requires that at all times a majority of the Board shall consist of Independent Directors;
+
+WHEREAS, it is necessary to elect two additional directors to satisfy these requirements and to properly constitute the Board;
+
+NOW, THEREFORE, BE IT RESOLVED as follows:
+
+---
+
+## Resolution 1: Election of Bridger Ryan Farnsworth
+
+Bridger Ryan Farnsworth is hereby elected as a director of the Corporation, effective June 23, 2026, to serve until a successor is duly elected and qualified or until earlier resignation or removal. The initial term class and expiration date for this directorship shall be established by resolution of the full Board at its first organizational action.
+
+---
+
+## Resolution 2: Election of Rachel B. Pickerel
+
+Rachel B. Pickerel is hereby elected as a director of the Corporation, effective June 23, 2026, to serve until a successor is duly elected and qualified or until earlier resignation or removal. The initial term class and expiration date for this directorship shall be established by resolution of the full Board at its first organizational action.
+
+---
+
+## Resolution 3: Independence Confirmation
+
+The initial director hereby confirms that, to the best of their knowledge, both Bridger Ryan Farnsworth and Rachel B. Pickerel qualify as Independent Directors within the meaning of Section 3.3 of the Bylaws. Following the election of these two directors, Independent Directors constitute a majority of the three-person Board, satisfying the requirement of Section 3.3.
+
+---
+
+## Signature Block
+
+The initial director identified below approves this written consent by approving the pull request introducing this document into the governance repository, as described in the Preamble.
+
+---
+
+**Enik Nadir Linden**, Initial Director  
+GitHub: @ENLinden


### PR DESCRIPTION
Adds the sole-initial-director written consent electing both additional directors, and updates the voter enforcement configuration to include their GitHub handles. Signed by the incoming board, per Delaware law and Article VII of the Bylaws. It is a prerequisite for the organizational consent PR that follows, which requires consent from the board as a quorum.
